### PR TITLE
Added code to remove obsolete dbversion setting

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -5071,6 +5071,8 @@ class serienRecSetup(Screen, ConfigListScreen):
 		config.plugins.serienRec.justplay.save()
 		config.plugins.serienRec.zapbeforerecord.save()
 		config.plugins.serienRec.justremind.save()
+		# Save obsolete dbversion config setting here to remove it from file
+		config.plugins.serienRec.dbversion.save();
 		
 		configfile.save()
 		self.close(True)


### PR DESCRIPTION
config.plugin.serienRec.dbversion is obsolete because it is saved in
database now, so we have to remove it from settings file
