### PR TITLE
Add new "Timername" setting "<Series name> - SnnEmm"

### DIFF
--- a/src/SerienRecorderMarkerScreen.py
+++ b/src/SerienRecorderMarkerScreen.py
@@ -1900,6 +1900,8 @@ class serienRecSendeTermine(serienRecBaseScreen, Screen, HelpableScreen):
 					timer_name = label_serie
 				elif config.plugins.serienRec.TimerName.value == "2":
 					timer_name = "S%sE%s - %s" % (str(staffel).zfill(2), str(episode).zfill(2), title)
+				elif config.plugins.serienRec.TimerName.value == "3":
+					timer_name = "%s - S%sE%s" % (serien_name, str(staffel).zfill(2), str(episode).zfill(2))
 				else:
 					timer_name = serien_name
 

--- a/src/SerienRecorderSetupScreen.py
+++ b/src/SerienRecorderSetupScreen.py
@@ -160,7 +160,7 @@ def ReadConfigFile():
 	config.plugins.serienRec.logWrapAround = ConfigYesNo(default=False)
 	config.plugins.serienRec.TimerName = ConfigSelection(
 		choices=[("0", "<Serienname> - SnnEmm - <Episodentitel>"), ("1", "<Serienname>"),
-		         ("2", "SnnEmm - <Episodentitel>")], default="0")
+		         ("2", "SnnEmm - <Episodentitel>"), ("3", "<Serienname> - SnnEmm")], default="0")
 	config.plugins.serienRec.refreshViews = ConfigYesNo(default=True)
 	config.plugins.serienRec.openMarkerScreen = ConfigYesNo(default=True)
 	config.plugins.serienRec.downloadCover = ConfigYesNo(default=False)

--- a/src/SerienRecorderTimer.py
+++ b/src/SerienRecorderTimer.py
@@ -60,6 +60,9 @@ class serienRecTimer:
 								elif config.plugins.serienRec.TimerName.value == "2":
 									timer_name = "S%sE%s - %s" % (
 									str(staffel).zfill(2), str(episode).zfill(2), serien_title)
+								elif config.plugins.serienRec.TimerName.value == "3":
+									timer_name = "%s - S%sE%s" % (
+									serien_name, str(staffel).zfill(2), str(episode).zfill(2))
 								else:
 									timer_name = serien_name
 									SRLogger.writeLog("Versuche deaktivierten Timer zu aktivieren: ' %s - %s '" % (
@@ -128,6 +131,9 @@ class serienRecTimer:
 								elif config.plugins.serienRec.TimerName.value == "2":
 									timer_name = "S%sE%s - %s" % (
 									str(staffel).zfill(2), str(episode).zfill(2), serien_title)
+								elif config.plugins.serienRec.TimerName.value == "3":
+									timer_name = "%s - S%sE%s" % (
+									serien_name, str(staffel).zfill(2), str(episode).zfill(2))
 								else:
 									timer_name = serien_name
 									SRLogger.writeLog("Versuche deaktivierten Timer aktiv zu erstellen: ' %s - %s '" % (
@@ -185,6 +191,8 @@ class serienRecTimer:
 						timer_name = "%s - S%sE%s - %s" % (serien_name, str(staffel).zfill(2), str(episode).zfill(2), new_serien_title)
 					elif config.plugins.serienRec.TimerName.value == "2":
 						timer_name = "S%sE%s - %s" % (str(staffel).zfill(2), str(episode).zfill(2), new_serien_title)
+					elif config.plugins.serienRec.TimerName.value == "3":
+						timer_name = "%s - S%sE%s" % (serien_name, str(staffel).zfill(2), str(episode).zfill(2))
 					else:
 						timer_name = serien_name
 
@@ -629,6 +637,8 @@ class serienRecTimer:
 				timer_name = label_serie
 			elif config.plugins.serienRec.TimerName.value == "2":
 				timer_name = "%s - %s" % (seasonEpisodeString, title)
+			elif config.plugins.serienRec.TimerName.value == "3":
+				timer_name = "%s - %s" % (serien_name, seasonEpisodeString)
 			else:
 				timer_name = serien_name
 			result = serienRecBoxTimer.addTimer(stbRef, str(start_unixtime), str(end_unixtime), timer_name,

--- a/src/SerienRecorderTimerListScreen.py
+++ b/src/SerienRecorderTimerListScreen.py
@@ -244,6 +244,8 @@ class serienRecTimerListScreen(serienRecBaseScreen, Screen, HelpableScreen):
 			title = serien_name
 		elif config.plugins.serienRec.TimerName.value == "2":  # "SnnEmm - <Episodentitel>"
 			title = "S%sE%s - %s" % (str(staffel).zfill(2), str(episode).zfill(2), serien_title)
+		elif config.plugins.serienRec.TimerName.value == "3":  # "<Serienname> - SnnEmm"
+			title = "%s - S%sE%s" % (serien_name, str(staffel).zfill(2), str(episode).zfill(2))
 		else:  # "<Serienname> - SnnEmm - <Episodentitel>"
 			title = "%s - S%sE%s - %s" % (serien_name, str(staffel).zfill(2), str(episode).zfill(2), serien_title)
 


### PR DESCRIPTION
Minor change to have a new setting for the timername.
Tested on DreamOS, but I don't see anything that could break anywhere else.

I need this change to align my settings of serienrecorder and SeriesPlugin.
Future work: Make description also adjustable in serienrecorder to align everything with SeriesPlugin.